### PR TITLE
Fix typo, remove double declaration

### DIFF
--- a/AirQualitySensorSW/LightOutput.ino
+++ b/AirQualitySensorSW/LightOutput.ino
@@ -64,7 +64,7 @@ void initWS2812() {
 
 void initLEDAnimation() {
   //CHECK LDR - if very dark damp the brightness
-  workingBrighness = getCalculatedBrightness();
+  workingBrightness = getCalculatedBrightness();
 
   LEDS.setBrightness(100 * workingBrightness);
 

--- a/AirQualitySensorSW/SerialUtil.ino
+++ b/AirQualitySensorSW/SerialUtil.ino
@@ -5,7 +5,7 @@ bool doesPrintSerialMessages = true;  // Flag to control serial printing
 void enableSerial() {
   doesPrintSerialMessages = true;
   Serial.begin(115200);
-  Serial.setTxTimeoutMs(0);
+  //Serial.setTxTimeoutMs(0); // TODO: Fix-up
 
   Serial.print("__________________________\n");
   Serial.print("|                        |\n");

--- a/AirQualitySensorSW/SerialUtil.ino
+++ b/AirQualitySensorSW/SerialUtil.ino
@@ -5,7 +5,7 @@ bool doesPrintSerialMessages = true;  // Flag to control serial printing
 void enableSerial() {
   doesPrintSerialMessages = true;
   Serial.begin(115200);
-  //Serial.setTxTimeoutMs(0); // TODO: Fix-up
+  Serial.setTxTimeoutMs(0); // NOTE: USB CDC On Boot has to be "Enabled"
 
   Serial.print("__________________________\n");
   Serial.print("|                        |\n");

--- a/AirQualitySensorSW/other.ino
+++ b/AirQualitySensorSW/other.ino
@@ -60,19 +60,7 @@ uint64_t stringToUInt64(const String& str) {
   }
   return result;
 }
-float fConstrain(float val, float min, float max) {
-    // First ensure we handle the case where min is greater than max
-    if (min > max) {
-        float temp = min;
-        min = max;
-        max = temp;
-    }
-    
-    // Return constrained value
-    if (val < min) return min;
-    if (val > max) return max;
-    return val;
-}
+
 float fConstrain(float val, float min, float max) {
     // First ensure we handle the case where min is greater than max
     if (min > max) {


### PR DESCRIPTION
Hey there,
let me preface this by saying that I've been out of the hardware game for quite some time, so I might be a bit rusty 😅.

I've tried to follow along with instructions in the README and these are the changes needed to successfully compile the firmware.

The weird thing is the missing setTxTimeoutMs method - it's using the [HardwareSerial.h](https://github.com/espressif/arduino-esp32/blob/master/cores/esp32/HardwareSerial.h) which does not have it defined, only [HWCDC.h](https://github.com/espressif/arduino-esp32/blob/master/cores/esp32/HWCDC.h#L60) & [USBCDC.h](https://github.com/espressif/arduino-esp32/blob/master/cores/esp32/USBCDC.h#L71) do 🤔.